### PR TITLE
Honor ROW_LIMIT setting in elasticsearch queries

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -379,6 +379,9 @@ class Database(
 
         with closing(engine.raw_connection()) as conn:
             cursor = conn.cursor()
+            if hasattr(cursor, 'fetch_size'):
+                cursor.fetch_size = config['ROW_LIMIT']
+                
             for sql_ in sqls[:-1]:
                 _log_query(sql_)
                 self.db_engine_spec.execute(cursor, sql_)


### PR DESCRIPTION
### SUMMARY
In order to adjust the fetch size of the elasticsearch-dbapi (https://github.com/preset-io/elasticsearch-dbapi#fetch-size) to the ROW_LIMIT setting, the fetch_size attribute of the cursor needs to be set.

### TESTING INSTRUCTIONS
- set ROW_LIMIT=20000 in config.py
- set ROW_LIMIT=50000 in a chart that uses an Elasticsearch data set
- run query on a sufficiently large data set
- observe that 20k rows are displayed in the chart

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
